### PR TITLE
Add legacy Docker Compose file for Windows deployments

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ documentation on the [Overleaf Wiki](https://github.com/overleaf/overleaf/wiki)
 
 - [The Doctor](./the-doctor.md)
 - [Working with Docker-Compose Services](./docker-compose.md)
+- [Legacy Docker Compose for Windows](./legacy-docker-compose.md)
 
 
 ## Configuration

--- a/doc/legacy-docker-compose.md
+++ b/doc/legacy-docker-compose.md
@@ -1,0 +1,22 @@
+# Legacy Docker Compose for Windows
+
+The toolkit primarily uses shell scripts to orchestrate multiple Compose
+fragments. On Windows, running these scripts can be inconvenient, so a
+stand‑alone `docker-compose.legacy.yml` is provided as a simple alternative.
+
+## Usage
+
+1. Ensure Docker and Docker Compose v2 are installed.
+2. Create `config/variables.env` with the desired settings.
+3. Start the services:
+
+   ```sh
+   docker compose -f docker-compose.legacy.yml up -d
+   ```
+
+The containers store their data under the local `data/` directory. Feel free
+to adjust paths and other environment variables via the `.env` file or the
+`config/variables.env` file.
+
+This compose file is intended for legacy deployments and is not actively
+developed. For production deployments, prefer the toolkit shell scripts.

--- a/docker-compose.legacy.yml
+++ b/docker-compose.legacy.yml
@@ -1,0 +1,95 @@
+version: "3.9"
+
+services:
+  sharelatex:
+    image: sharelatex/sharelatex:latest
+    container_name: sharelatex
+    restart: always
+    ports:
+      - "${OVERLEAF_LISTEN_IP:-0.0.0.0}:${OVERLEAF_PORT:-80}:80"
+    environment:
+      OVERLEAF_MONGO_URL: ${MONGO_URL:-mongodb://mongo/sharelatex}
+      OVERLEAF_REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      GIT_BRIDGE_ENABLED: ${GIT_BRIDGE_ENABLED:-false}
+      GIT_BRIDGE_HOST: git-bridge
+      GIT_BRIDGE_PORT: 8000
+      V1_HISTORY_URL: http://sharelatex:3100/api
+      OVERLEAF_SECURE_COOKIE: "true"
+      OVERLEAF_TRUSTED_PROXY_IPS: ${OVERLEAF_TRUSTED_PROXY_IPS:-loopback,172.16.0.0/12}
+      OVERLEAF_BEHIND_PROXY: "true"
+    volumes:
+      - ${OVERLEAF_DATA_PATH:-./data/sharelatex}:/var/lib/overleaf
+      - ${OVERLEAF_LOG_PATH:-./data/logs}:/var/log/overleaf
+      # 如需使用 sibling containers，请取消下行注释
+      # - /var/run/docker.sock:/var/run/docker.sock
+    env_file:
+      - ./config/variables.env
+    depends_on:
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      git-bridge:
+        condition: service_started
+      nginx:
+        condition: service_started
+    links:
+      - mongo
+      - redis
+      - git-bridge
+    stop_grace_period: 60s
+
+  mongo:
+    image: ${MONGO_DOCKER_IMAGE:-mongo:4.0}
+    container_name: mongo
+    restart: always
+    command: ${MONGO_ARGS:--replSet overleaf}
+    volumes:
+      - ${MONGO_DATA_PATH:-./data/mongo}:/data/db
+    expose:
+      - 27017
+    healthcheck:
+      test: ["CMD-SHELL", "echo 'db.stats().ok' | mongosh localhost:27017/test --quiet"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+  redis:
+    image: ${REDIS_IMAGE:-redis:5.0}
+    container_name: redis
+    restart: always
+    command: ${REDIS_COMMAND:--appendonly yes}
+    volumes:
+      - ${REDIS_DATA_PATH:-./data/redis}:/data
+    expose:
+      - 6379
+
+  git-bridge:
+    image: ${GIT_BRIDGE_IMAGE:-overleaf/git-bridge:latest}
+    container_name: git-bridge
+    restart: always
+    volumes:
+      - ${GIT_BRIDGE_DATA_PATH:-./data/git-bridge}:/data/git-bridge
+    environment:
+      GIT_BRIDGE_API_BASE_URL: ${GIT_BRIDGE_API_BASE_URL:-http://sharelatex:3000/api/v0/}
+      GIT_BRIDGE_OAUTH2_SERVER: http://sharelatex
+      GIT_BRIDGE_POSTBACK_BASE_URL: http://git-bridge:8000
+      GIT_BRIDGE_ROOT_DIR: /data/git-bridge
+      LOG_LEVEL: ${GIT_BRIDGE_LOG_LEVEL:-INFO}
+    env_file:
+      - ./config/variables.env
+    expose:
+      - 8000
+
+  nginx:
+    image: ${NGINX_IMAGE:-nginx:1.28-alpine}
+    container_name: nginx
+    restart: always
+    ports:
+      - "${NGINX_TLS_LISTEN_IP:-0.0.0.0}:${TLS_PORT:-443}:443"
+      - "${NGINX_HTTP_LISTEN_IP:-127.0.1.1}:${NGINX_HTTP_PORT:-80}:80"
+    volumes:
+      - ${TLS_PRIVATE_KEY_PATH:-./certs/nginx_key.pem}:/certs/nginx_key.pem:ro
+      - ${TLS_CERTIFICATE_PATH:-./certs/nginx_certificate.pem}:/certs/nginx_certificate.pem:ro
+      - ${NGINX_CONFIG_PATH:-./config/nginx/nginx.conf}:/etc/nginx/nginx.conf:ro


### PR DESCRIPTION
## Summary
- provide standalone `docker-compose.legacy.yml` for Windows users
- document legacy compose usage and reference in docs

## Testing
- `bin/doctor` *(fails: head: cannot open '/workspace/toolkit/config/version')*
- `docker compose -f docker-compose.legacy.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5227e43848329a73654936421bdf8